### PR TITLE
Add support for Ollama, Palm, Claude-2, Cohere, Replicate Llama2, CodeLlama, Hugging Face (100+LLMs) - using LiteLLM

### DIFF
--- a/autoagents/system/provider/openai_api.py
+++ b/autoagents/system/provider/openai_api.py
@@ -11,6 +11,7 @@ from functools import wraps
 from typing import NamedTuple
 
 import openai
+import litellm
 
 from autoagents.system.config import CONFIG
 from autoagents.system.logs import logger
@@ -145,22 +146,22 @@ class OpenAIGPTAPI(BaseGPTAPI, RateLimiter):
         if self.proxy != '':
             openai.proxy = self.proxy
         else:
-            openai.api_key = config.openai_api_key
+            litellm.api_key = config.openai_api_key
         
         if self.api_key != '':
-            openai.api_key = self.api_key
+            litellm.api_key = self.api_key
         else:
-            openai.api_key = config.openai_api_key
+            litellm.api_key = config.openai_api_key
         
         if config.openai_api_base:
-            openai.api_base = config.openai_api_base
+            litellm.api_base = config.openai_api_base
         if config.openai_api_type:
-            openai.api_type = config.openai_api_type
-            openai.api_version = config.openai_api_version
+            litellm.api_type = config.openai_api_type
+            litellm.api_version = config.openai_api_version
         self.rpm = int(config.get("RPM", 10))
 
     async def _achat_completion_stream(self, messages: list[dict]) -> str:
-        response = await openai.ChatCompletion.acreate(
+        response = await litellm.acompletion(
             **self._cons_kwargs(messages),
             stream=True
         )

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ loguru==0.6.0
 meilisearch==0.21.0
 numpy==1.24.3
 openai==0.27.8
+litellm
 openpyxl
 pandas==1.4.1
 pydantic==1.10.7


### PR DESCRIPTION
This PR adds support for the above mentioned LLMs using LiteLLM https://github.com/BerriAI/litellm/ 
LiteLLM is a lightweight package to simplify LLM API calls - use any llm as a drop in replacement for gpt-3.5-turbo. 


Example
```python
from litellm import completion

## set ENV variables
os.environ["OPENAI_API_KEY"] = "openai key"
os.environ["COHERE_API_KEY"] = "cohere key"

messages = [{ "content": "Hello, how are you?","role": "user"}]

# openai call
response = completion(model="gpt-3.5-turbo", messages=messages)

# cohere call
response = completion(model="command-nightly", messages)

# anthropic call
response = completion(model="claude-instant-1", messages=messages)
```

## Async Completion
```python
from litellm import acompletion
## set ENV variables
os.environ["OPENAI_API_KEY"] = "openai key"
os.environ["COHERE_API_KEY"] = "cohere key"

messages = [{ "content": "Hello, how are you?","role": "user"}]

# openai call
response = acompletion(model="gpt-3.5-turbo", messages=messages)

# cohere call
response = acompletion(model="command-nightly", messages)

# anthropic call
response = acompletion(model="claude-instant-1", messages=messages)
```